### PR TITLE
Simple implementation for crossOrigin support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var React = require('react');
 
 var defaultState = { image: undefined, status: 'loading' };
 
-module.exports = function useImage(url) {
+module.exports = function useImage(url, crossOrigin) {
   var res = React.useState(defaultState);
   var image = res[0].image;
   var status = res[0].status;
@@ -24,6 +24,7 @@ module.exports = function useImage(url) {
 
       img.addEventListener('load', onload);
       img.addEventListener('error', onerror);
+      crossOrigin && (img.crossOrigin = crossOrigin);
       img.src = url;
 
       return function cleanup() {


### PR DESCRIPTION
I have added `crossOrigin` param to the hook for handling images from different domains.
To somewhat prevent accidental setting of `crossOrigin`, I implemented it the way that user need to actually write the string value `Anonymous` to correctly set the `crossOrigin` rule.

Let me know what you think.
Also if you are ok with this PR, should I bump the version too?