### PR TITLE
set state back to default when cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function useImage(url, crossOrigin) {
       return function cleanup() {
         img.removeEventListener('load', onload);
         img.removeEventListener('error', onerror);
+        setState(defaultState);
       };
     },
     [url, crossOrigin]


### PR DESCRIPTION
Because when url changed, if we don't set state back to default, old image is still returned.