### PR TITLE
better crossOrigin type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare function useImage(
   url: string,
-  crossOrigin?: string
+  crossOrigin?: 'anonymous' | 'use-credentials'
 ): [undefined | HTMLImageElement, 'loaded' | 'loading' | 'failed'];
 
 export default useImage;


### PR DESCRIPTION
Because `crossOrigin`'s value is limited in `anonymous` and `use-credentials`