### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ function SimpleApp() {
 
 function ComplexApp() {
   // set crossOrigin of image as second argument
-  const [image, status] = useImage(url, 'Anonymous');
+  const [image, status] = useImage(url, 'anonymous');
 
   // status can be "loading", "loaded" or "failed"
 


### PR DESCRIPTION
Use lowercase string in the crossOrigin argument to satisfy type definitions.