### PR TITLE
Extending the functionality - include http headers in the request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 declare function useImage(
   url: string,
-  crossOrigin?: 'anonymous' | 'use-credentials'
-): [undefined | HTMLImageElement, 'loaded' | 'loading' | 'failed'];
+  crossOrigin?: "anonymous" | "use-credentials",
+  headers: Headers,
+  cache: "*default" | "no-cache" | "reload" | "force-cache" | "only-if-cached"
+): [undefined | HTMLImageElement, "loaded" | "loading" | "failed"];
 
 export default useImage;


### PR DESCRIPTION
My motivation is to make the package a bit more flexible and send custom http headers, for example auth token or cache-control headers.