### PR TITLE
Fix small typo for `referrerPolicy` arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function useImage(url, crossOrigin, referrerpolicy) {
       img.addEventListener('load', onload);
       img.addEventListener('error', onerror);
       crossOrigin && (img.crossOrigin = crossOrigin);
-      referrerpolicy && (img.referrerpolicy = referrerpolicy);
+      referrerpolicy && (img.referrerPolicy = referrerpolicy);
       img.src = url;
 
       return function cleanup() {


### PR DESCRIPTION
Fixes a single character case in this for the `referrerPolicy` argument.  While [it is all lower case](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#referrerpolicy) in HTML, as js object/`HTMLImageElement` [it is camel case](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy).