### PR TITLE
Fix default export declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,4 @@ declare function useImage(
   referrerpolicy?: 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url'
 ): [undefined | HTMLImageElement, 'loaded' | 'loading' | 'failed'];
 
-export default useImage;
+export = useImage;


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports

Here should be `export =` since the package is CommonJS.

Also got an error with Deno:

![](https://github.com/user-attachments/assets/5ce03248-7f64-4d47-a4b0-c63c404a10fd)
