### PR TITLE
fix: optimization for token updating

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,14 +48,14 @@ module.exports = function useImage(url, crossOrigin, referrerpolicy) {
           .finally(() => {
             statusRef.current = 'loaded';
             imageRef.current = img;
-            setStateToken(Math.random());
+            setStateToken(prevStateToken => prevStateToken + 1);
           });
       }
 
       function onerror() {
         statusRef.current = 'failed';
         imageRef.current = undefined;
-        setStateToken(Math.random());
+        setStateToken(prevStateToken => prevStateToken + 1);
       }
 
       img.addEventListener('load', onload);


### PR DESCRIPTION
Argumentation:

1. The probability of getting exactly the same number with Math.random() is greater than zero.
2. The addition operation is cheaper than generating a pseudo-random number.